### PR TITLE
Test updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ CMakeLists.txt.user*
 
 # build directories
 /build*
+
+# Hidden files
+*.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,6 @@ foreach(_MODULE ${INST_MODULE_NAMES})
     if(NOT _IS_REF)
         list(APPEND _INTERFACE_LIBS instrument-enabled)
     endif()
-    message(STATUS "${_MODULE} is reference: ${_IS_REF}")
 
     list(REMOVE_DUPLICATES _INTERFACE_LIBS)
     message(STATUS "${_MODULE} interface libraries: ${_INTERFACE_LIBS}")
@@ -310,3 +309,6 @@ endforeach()
 
 configure_file(${PROJECT_SOURCE_DIR}/examples/execute.py
     ${CMAKE_BINARY_DIR}/execute.py COPYONLY)
+
+configure_file(${PROJECT_SOURCE_DIR}/examples/execute.sh
+    ${CMAKE_BINARY_DIR}/execute.sh COPYONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,13 +127,13 @@ define_submodule(
     EXTRA_LANGUAGES     C
 )
 
-define_submodule(
-    NAME                dormant
-    LANGUAGE            CXX
-    HEADER_FILE         ../fallback_inst.h
-    INTERFACE_LIBRARY   fallback-config
-    EXTRA_LANGUAGES     C
-)
+# define_submodule(
+#     NAME                dormant
+#     LANGUAGE            CXX
+#     HEADER_FILE         ../fallback_inst.h
+#     INTERFACE_LIBRARY   fallback-config
+#     EXTRA_LANGUAGES     C
+# )
 
 # get all the modules
 get_property(INST_MODULE_NAMES GLOBAL PROPERTY INST_MODULE_NAMES)
@@ -163,9 +163,14 @@ foreach(_MODULE ${INST_MODULE_NAMES})
         list(APPEND _INTERFACE_LIBS ${_ENTRY}-language)
     endforeach()
 
+    if(TARGET global-config)
+        list(APPEND _INTERFACE_LIBS global-config)
+    endif()
+
     if(NOT _IS_REF)
         list(APPEND _INTERFACE_LIBS instrument-enabled)
     endif()
+    message(STATUS "${_MODULE} is reference: ${_IS_REF}")
 
     list(REMOVE_DUPLICATES _INTERFACE_LIBS)
     message(STATUS "${_MODULE} interface libraries: ${_INTERFACE_LIBS}")
@@ -212,7 +217,7 @@ foreach(_MODULE ${INST_MODULE_NAMES})
     # create library
     add_library(inst-bench-${_TARGET_MODULE} SHARED ${_TARGET_SOURCES} ${_TARGET_HEADERS})
     target_link_libraries(inst-bench-${_TARGET_MODULE}
-        PUBLIC instrument-headers instrument-enabled ${_INTERFACE_LIBS})
+        PUBLIC instrument-headers ${_INTERFACE_LIBS})
     set_target_properties(inst-bench-${_TARGET_MODULE} PROPERTIES
         ARCHIVE_OUTPUT_DIRECTORY ${SUBMODULE_OUTPUT_PATH}
         LIBRARY_OUTPUT_DIRECTORY ${SUBMODULE_OUTPUT_PATH}

--- a/cmake/Modules/BuildSettings.cmake
+++ b/cmake/Modules/BuildSettings.cmake
@@ -27,10 +27,10 @@ add_target_flag_if_avail(instrument-compile-options
     "-faligned-new")
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-    add_target_flag(instrument-compile-options "-DDEBUG")
+    target_compile_definitions(instrument-compile-options INTERFACE DEBUG)
 endif()
 
-add_target_flag(instrument-enabled "-DUSE_INST")
+target_compile_definitions(instrument-enabled INTERFACE USE_INST)
 
 #----------------------------------------------------------------------------------------#
 # user customization

--- a/examples/execute.py
+++ b/examples/execute.py
@@ -118,7 +118,7 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--size", type=int,
                         default=100, help="Matrix size (N x N)")
     parser.add_argument("-e", "--entries", type=int,
-                        default=100, help="Number of timing entries")
+                        default=50, help="Number of timing entries")
     # specific to FIBONACCI
     parser.add_argument("-f", "--fibonacci", type=int,
                         default=43, help="Fibonacci value")

--- a/examples/execute.py
+++ b/examples/execute.py
@@ -9,12 +9,13 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-lout = open('log.txt', 'w')
+lout = None
 
 
 def lprint(message):
     print("{}".format(message))
-    lout.write("{}\n".format(message))
+    if lout is not None:
+        lout.write("{}\n".format(message))
 
 
 def plot(x, y, yerr, label, fname):
@@ -125,6 +126,9 @@ if __name__ == "__main__":
                         default=23, help="Fibonacci cutoff")
 
     args = parser.parse_args()
+
+    # log file
+    lout = open("{}.txt".format(args.prefix.strip('_')), 'w')
 
     m_N = args.size         # matrix size is N x N
     m_I = args.iterations   # number of iterations per timing entry

--- a/examples/execute.py
+++ b/examples/execute.py
@@ -163,8 +163,8 @@ if __name__ == "__main__":
         plot(fib_keys, fib_time_data["y"],
              fib_time_data["yerr"], "Fibonacci({}, {}) Runtime".format(
                  m_F, m_C),
-             "{}_FIBONACCI_RUNTIME.png".format(args.prefix.upper()))
+             "{}_FIBONACCI_RUNTIME.png".format(args.prefix.upper().strip("_")))
         plot(fib_keys, fib_over_data["y"],
              fib_over_data["yerr"], "Fibonacci({}, {}) Overhead".format(
                  m_F, m_C),
-             "{}_FIBONACCI_OVERHEAD.png".format(args.prefix.upper()))
+             "{}_FIBONACCI_OVERHEAD.png".format(args.prefix.upper().strip("_")))

--- a/examples/execute.py
+++ b/examples/execute.py
@@ -179,6 +179,7 @@ if __name__ == "__main__":
 
     if "fibonacci" in args.modes:
         for lang in args.languages:
+            baseline = None
             for submodule in submodules:
                 key = "[{}]> {}_{}".format(
                     lang.upper(), "FIBONACCI", submodule.upper())

--- a/examples/execute.py
+++ b/examples/execute.py
@@ -1,37 +1,102 @@
 #!/usr/bin/env python
 
 import os
-import statistics
+import argparse
+import instrument_benchmark as bench
+from statistics import mean, stdev
 
 
-def print_info(results, label):
+def print_info(results, label, chunk_size=5):
 
-    _timing = ", ".join(["{:10.3e}".format(i) for i in results.timing()])
-    _overhead = ", ".join(["{:10.3e}".format(i) for i in results.overhead()])
-    _foverhead = results.overhead()[1:]
+    nchunk = (len(results.timing()) - 1) / chunk_size
+    nmodulo = (len(results.timing()) - 1) % chunk_size
+    nitr = int(nchunk + 1 if nmodulo > 0 else nchunk)
+    _time = ""
+    _over = ""
+    _inst = ""
+    for i in range(nitr+1):
+        if i == 0:
+            beg = 0
+            end = 1
+        else:
+            beg = (i - 1) * chunk_size + 1
+            end = i * chunk_size + 1
+        if end > len(results.timing()):
+            end = len(results.timing())
+        _rtime = results.timing()[beg:end]
+        _rover = results.overhead()[beg:end]
+        _rinst = results.inst_count()[beg:end]
+        _t = ", ".join(["{:10.3e}".format(i) for i in _rtime])
+        _o = ", ".join(["{:10.3e}".format(i) for i in _rover])
+        _i = ", ".join(["{:10}".format(i) for i in _rinst])
+        if i > 0:
+            _time = "{}\n\t{:23}{}".format(_time, "", _t)
+            _over = "{}\n\t{:23}{}".format(_over, "", _o)
+            _inst = "{}\n\t{:23}{}".format(_inst, "", _i)
+        else:
+            _time = "{}  {:>10}".format(_t, "baseline")
+            _over = "{}  {:>10}".format(_o, "baseline")
+            _inst = "{}  {:>10}".format(_i, "baseline")
+    _time = _time.strip("\n")
+    _over = _over.strip("\n")
+    _inst = _inst.strip("\n")
+    _ftime = results.timing()[1:]
+    _fover = results.overhead()[1:]
 
     print("\n{}".format(label))
-    print("\t{:20} : {}".format("entries", results.entries()))
-    print("\t{:20} : {}".format("runtime (sec)", _timing))
-    print("\t{:20} : {}".format("overhead (sec)", _overhead))
-    print("\t{:20} : {:10.3e}".format("avg overhead", statistics.mean(_foverhead)))
-    print("\t{:20} : {:10.3e}".format("std-dev overhead", statistics.stdev(_foverhead)))
+    print("\t{:20} : {:10}".format("entries", results.entries()))
+    print("")
+    print("\t{:20} : {}".format("instrument (count)", _inst))
+    print("")
+    print("\t{:20} : {}".format("runtime (sec)", _time))
+    print("")
+    print("\t{:20} : {}".format("overhead (sec)", _over))
+    print("")
+    print("\t{:20} : {:10.3e}".format("runtime (mean)", mean(_ftime)))
+    print("\t{:20} : {:10.3e}".format("runtime (stdev)", stdev(_ftime)))
+    print("\t{:20} : {:10.3e}".format("overhead (mean)", mean(_fover)))
+    print("\t{:20} : {:10.3e}".format("overhead (stdev)", stdev(_fover)))
 
 
 if __name__ == "__main__":
 
-    os.environ["TIMEMORY_ENABLED"] = "OFF"
-    import instrument_benchmark as bench
+    parser = argparse.ArgumentParser()
 
-    m_N = 50      # matrix size is N x N
-    m_I = 200     # number of iterations per timing entry
-    m_E = 5       # number of timing entries
+    parser.add_argument("-n", "--size", type=int,
+                        default=50, help="Matrix size (N x N)")
+    parser.add_argument("-i", "--iterations", type=int, default=100,
+                        help="Number of iterations per timing entry")
+    parser.add_argument("-e", "--entries", type=int,
+                        default=50, help="Number of timing entries")
+    parser.add_argument("-f", "--fibonacci", type=int,
+                        default=43, help="Fibonacci value")
+    parser.add_argument("-c", "--cutoff", type=int,
+                        default=23, help="Fibonacci cutoff")
+    parser.add_argument("-m", "--modes", type=str, nargs='*',
+                        default=["fibonacci", "matrix"], choices=["fibonacci", "matrix"])
 
-    for lang in ["c", "cxx"]:
-        for submodule in bench.submodules:
-            ret = getattr(bench, submodule).matmul(m_N, m_I, m_E, lang)
-            if ret is not None:
-                print_info(ret, "[{:^3}]> {}".format(lang, submodule))
-            else:
-                print("[{:^3}]> {} returned None".format(lang, submodule))
-            print("")  # spacing
+    args = parser.parse_args()
+
+    m_N = args.size         # matrix size is N x N
+    m_I = args.iterations   # number of iterations per timing entry
+    m_E = args.entries      # number of timing entries
+    m_F = args.fibonacci    # fibonacci value
+    m_C = args.cutoff       # cutoff value
+
+    if "matrix" in args.modes:
+        for lang in ["c", "cxx"]:
+            for submodule in sorted(bench.submodules):
+                ret = getattr(bench, submodule).matmul(m_N, m_I, m_E, lang)
+                if ret is not None:
+                    print_info(ret, "[{:^3}]> {}".format(
+                        lang, submodule.upper()))
+                    print("")  # spacing
+
+    if "fibonacci" in args.modes:
+        for lang in ["cxx"]:
+            for submodule in sorted(bench.submodules):
+                ret = getattr(bench, submodule).fibonacci(m_F, m_C, m_I, lang)
+                if ret is not None:
+                    print_info(ret, "[{:^3}]> {}".format(
+                        lang, submodule.upper()))
+                    print("")  # spacing

--- a/examples/execute.sh
+++ b/examples/execute.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 
-: ${ARGS:="-i 50 -l cxx"}
+: ${ARGS:="-i 25 -f 40 -c 15"}
+
+rm -rf DISABLED* ENABLED_WALL_CLOCK* \
+    timemory-enabled-wall-clock-output
 
 #----------------------------------------------------------#
 #       Disabled
@@ -14,4 +17,5 @@ python ./execute.py -p DISABLED ${ARGS} $@
 #----------------------------------------------------------#
 export CALI_CONFIG_PROFILE=runtime-report
 export TIMEMORY_ENABLED=ON
+export TIMEMORY_OUTPUT_PATH=timemory-enabled-wall-clock-output
 python ./execute.py -p ENABLED_WALL_CLOCK ${ARGS} $@

--- a/examples/execute.sh
+++ b/examples/execute.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+
+: ${ARGS:="-i 50 -l cxx"}
+
+#----------------------------------------------------------#
+#       Disabled
+#----------------------------------------------------------#
+unset CALI_CONFIG_PROFILE
+export TIMEMORY_ENABLED=OFF
+python ./execute.py -p DISABLED ${ARGS} $@
+
+#----------------------------------------------------------#
+#       Enabled
+#----------------------------------------------------------#
+export CALI_CONFIG_PROFILE=runtime-report
+export TIMEMORY_ENABLED=ON
+python ./execute.py -p ENABLED_WALL_CLOCK ${ARGS} $@

--- a/examples/timemory/UserSettings.cmake
+++ b/examples/timemory/UserSettings.cmake
@@ -1,0 +1,64 @@
+
+# common list of components
+set(TIMEMORY_COMPONENTS headers c cxx compile-options arch)
+
+find_package(timemory REQUIRED COMPONENTS ${TIMEMORY_COMPONENTS})
+
+add_library(timemory-config INTERFACE)
+target_link_libraries(timemory-config INTERFACE timemory)
+if(CMAKE_CXX_COMPILER_IS_GNU)
+    target_compile_options(timemory-config INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>)
+endif()
+
+define_submodule(
+    NAME                get_record
+    LANGUAGE            CXX
+    HEADER_FILE         timemory_cxx_get_library.hpp
+    INTERFACE_LIBRARY   timemory-config
+    EXTRA_LANGUAGES     C
+)
+
+define_submodule(
+    NAME                ptr_record
+    LANGUAGE            CXX
+    HEADER_FILE         timemory_cxx_ptr_library.hpp
+    INTERFACE_LIBRARY   timemory-config
+    EXTRA_LANGUAGES     C
+)
+
+define_submodule(
+    NAME                variadic_enum
+    LANGUAGE            C
+    HEADER_FILE         timemory_c_enum_library.h
+    INTERFACE_LIBRARY   timemory-config
+)
+
+define_submodule(
+    NAME                template
+    LANGUAGE            CXX
+    HEADER_FILE         timemory_cxx_templates.hpp
+    INTERFACE_LIBRARY   timemory-config
+)
+
+define_submodule(
+    NAME                template_ptr
+    LANGUAGE            CXX
+    HEADER_FILE         timemory_cxx_templates_pointer.hpp
+    INTERFACE_LIBRARY   timemory-config
+)
+
+define_submodule(
+    NAME                cali_thread_scope
+    LANGUAGE            CXX
+    HEADER_FILE         caliper_thread_scope.h
+    INTERFACE_LIBRARY   timemory-config timemory-caliper
+    EXTRA_LANGUAGES     C
+)
+
+define_submodule(
+    NAME                cali_process_scope
+    LANGUAGE            CXX
+    HEADER_FILE         caliper_process_scope.h
+    INTERFACE_LIBRARY   timemory-config timemory-caliper
+    EXTRA_LANGUAGES     C
+)

--- a/examples/timemory/caliper_process_scope.h
+++ b/examples/timemory/caliper_process_scope.h
@@ -29,7 +29,7 @@
 
 #include <caliper/cali.h>
 
-#define INSTRUMENT_CONFIGURE()
+#define INSTRUMENT_CONFIGURE() cali_init();
 #define INSTRUMENT_CREATE(...)                                                           \
     cali_id_t _id = cali_create_attribute("inst", CALI_TYPE_STRING,                      \
                                           CALI_ATTR_NESTED | CALI_ATTR_SCOPE_PROCESS);

--- a/examples/timemory/caliper_process_scope.h
+++ b/examples/timemory/caliper_process_scope.h
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if defined(__cplusplus)
+#    include <iostream>
+#    include <string>
+#else
+#    include <stdint.h>
+#endif
+
+#include <caliper/cali.h>
+
+#define INSTRUMENT_CONFIGURE()
+#define INSTRUMENT_CREATE(...)                                                           \
+    cali_id_t _id = cali_create_attribute("inst", CALI_TYPE_STRING,                      \
+                                          CALI_ATTR_NESTED | CALI_ATTR_SCOPE_PROCESS);
+#define INSTRUMENT_START(...) cali_begin_string(_id, __FUNCTION__);
+#define INSTRUMENT_STOP(...) cali_end(_id);

--- a/examples/timemory/caliper_thread_scope.h
+++ b/examples/timemory/caliper_thread_scope.h
@@ -1,0 +1,37 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if defined(__cplusplus)
+#    include <iostream>
+#    include <string>
+#else
+#    include <stdint.h>
+#endif
+
+#include <caliper/cali.h>
+
+#define INSTRUMENT_CONFIGURE()
+#define INSTRUMENT_CREATE(...)                                                           \
+    cali_id_t _id = cali_create_attribute("inst", CALI_TYPE_STRING,                      \
+                                          CALI_ATTR_NESTED | CALI_ATTR_SCOPE_THREAD);
+#define INSTRUMENT_START(...) cali_begin_string(_id, __FUNCTION__);
+#define INSTRUMENT_STOP(...) cali_end(_id);

--- a/examples/timemory/caliper_thread_scope.h
+++ b/examples/timemory/caliper_thread_scope.h
@@ -29,7 +29,7 @@
 
 #include <caliper/cali.h>
 
-#define INSTRUMENT_CONFIGURE()
+#define INSTRUMENT_CONFIGURE() cali_init();
 #define INSTRUMENT_CREATE(...)                                                           \
     cali_id_t _id = cali_create_attribute("inst", CALI_TYPE_STRING,                      \
                                           CALI_ATTR_NESTED | CALI_ATTR_SCOPE_THREAD);

--- a/examples/timemory/configure.sh
+++ b/examples/timemory/configure.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -e
+
+#-----------------------------------------------------------#
+#
+#     Configure project for timemory benchmarking
+#
+#-----------------------------------------------------------#
+
+THIS_DIR=$(dirname ${BASH_SOURCE[0]})
+INC_DIR=${THIS_DIR}/../../include/user
+CMAKE_DIR=${THIS_DIR}/../../cmake
+
+# echo "${THIS_DIR}"
+# echo "${INC_DIR}"
+# echo "${CMAKE_DIR}"
+
+cp ${THIS_DIR}/*.h ${INC_DIR}/
+cp ${THIS_DIR}/*.hpp ${INC_DIR}/
+cp ${THIS_DIR}/*.cmake ${CMAKE_DIR}/

--- a/examples/timemory/timemory_c_enum_library.h
+++ b/examples/timemory/timemory_c_enum_library.h
@@ -25,16 +25,7 @@
 
 #include <timemory/ctimemory.h>
 
-#if defined(__cplusplus)
-#    include <timemory/timemory.hpp>
-#    define INSTRUMENT_CONFIGURE()                                                       \
-        {                                                                                \
-            tim::complete_list_t::get_initializer(tim::complete_list_t& al) = []() {};   \
-        }
-#else
-#    define INSTRUMENT_CONFIGURE()
-#endif
-
+#define INSTRUMENT_CONFIGURE()
 #define INSTRUMENT_CREATE(...)
 #define INSTRUMENT_START(name) void* timer = TIMEMORY_BASIC_MARKER("", WALL_CLOCK);
 #define INSTRUMENT_STOP(name) FREE_TIMEMORY_MARKER(timer);

--- a/examples/timemory/timemory_c_enum_library.h
+++ b/examples/timemory/timemory_c_enum_library.h
@@ -1,0 +1,40 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdio.h>
+#include <string.h>
+
+#include <timemory/ctimemory.h>
+
+#if defined(__cplusplus)
+#    include <timemory/timemory.hpp>
+#    define INSTRUMENT_CONFIGURE()                                                       \
+        {                                                                                \
+            tim::complete_list_t::get_initializer(tim::complete_list_t& al) = []() {};   \
+        }
+#else
+#    define INSTRUMENT_CONFIGURE()
+#endif
+
+#define INSTRUMENT_CREATE(...)
+#define INSTRUMENT_START(name) void* timer = TIMEMORY_BASIC_MARKER("", WALL_CLOCK);
+#define INSTRUMENT_STOP(name) FREE_TIMEMORY_MARKER(timer);

--- a/examples/timemory/timemory_cxx_get_library.hpp
+++ b/examples/timemory/timemory_cxx_get_library.hpp
@@ -21,24 +21,14 @@
 // SOFTWARE.
 
 #if defined(__cplusplus)
-#    include <iostream>
-#    include <string>
-#    include <timemory/timemory.hpp>
+#    include <cstdint>
 #else
 #    include <stdint.h>
 #endif
 
 #include <timemory/library.h>
 
-#if defined(__cplusplus)
-#    define INSTRUMENT_CONFIGURE()                                                       \
-        {                                                                                \
-            timemory_set_default("wall_clock");                                          \
-            tim::complete_list_t::get_initializer(tim::complete_list_t& al) = []() {};   \
-        }
-#else
-#    define INSTRUMENT_CONFIGURE()
-#endif
+#define INSTRUMENT_CONFIGURE() timemory_set_default("wall_clock");
 #define INSTRUMENT_CREATE(...)
 #define INSTRUMENT_START(name) uint64_t inst_id = timemory_get_begin_record(__FUNCTION__);
 #define INSTRUMENT_STOP(...) timemory_end_record(inst_id);

--- a/examples/timemory/timemory_cxx_get_library.hpp
+++ b/examples/timemory/timemory_cxx_get_library.hpp
@@ -1,0 +1,44 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if defined(__cplusplus)
+#    include <iostream>
+#    include <string>
+#    include <timemory/timemory.hpp>
+#else
+#    include <stdint.h>
+#endif
+
+#include <timemory/library.h>
+
+#if defined(__cplusplus)
+#    define INSTRUMENT_CONFIGURE()                                                       \
+        {                                                                                \
+            timemory_set_default("wall_clock");                                          \
+            tim::complete_list_t::get_initializer(tim::complete_list_t& al) = []() {};   \
+        }
+#else
+#    define INSTRUMENT_CONFIGURE()
+#endif
+#define INSTRUMENT_CREATE(...)
+#define INSTRUMENT_START(name) uint64_t inst_id = timemory_get_begin_record(__FUNCTION__);
+#define INSTRUMENT_STOP(...) timemory_end_record(inst_id);

--- a/examples/timemory/timemory_cxx_ptr_library.hpp
+++ b/examples/timemory/timemory_cxx_ptr_library.hpp
@@ -21,25 +21,14 @@
 // SOFTWARE.
 
 #if defined(__cplusplus)
-#    include <iostream>
-#    include <string>
-#    include <timemory/timemory.hpp>
+#    include <cstdint>
 #else
 #    include <stdint.h>
 #endif
 
 #include <timemory/library.h>
 
-#if defined(__cplusplus)
-#    define INSTRUMENT_CONFIGURE()                                                       \
-        {                                                                                \
-            timemory_set_default("wall_clock");                                          \
-            tim::complete_list_t::get_initializer(tim::complete_list_t& al) = []() {};   \
-        }
-#else
-#    define INSTRUMENT_CONFIGURE()
-#endif
-
+#define INSTRUMENT_CONFIGURE() timemory_set_default("wall_clock");
 #define INSTRUMENT_CREATE(...) uint64_t inst_id;
 #define INSTRUMENT_START(name) timemory_begin_record(__FUNCTION__, &inst_id);
 #define INSTRUMENT_STOP(...) timemory_end_record(inst_id);

--- a/examples/timemory/timemory_cxx_ptr_library.hpp
+++ b/examples/timemory/timemory_cxx_ptr_library.hpp
@@ -1,0 +1,45 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#if defined(__cplusplus)
+#    include <iostream>
+#    include <string>
+#    include <timemory/timemory.hpp>
+#else
+#    include <stdint.h>
+#endif
+
+#include <timemory/library.h>
+
+#if defined(__cplusplus)
+#    define INSTRUMENT_CONFIGURE()                                                       \
+        {                                                                                \
+            timemory_set_default("wall_clock");                                          \
+            tim::complete_list_t::get_initializer(tim::complete_list_t& al) = []() {};   \
+        }
+#else
+#    define INSTRUMENT_CONFIGURE()
+#endif
+
+#define INSTRUMENT_CREATE(...) uint64_t inst_id;
+#define INSTRUMENT_START(name) timemory_begin_record(__FUNCTION__, &inst_id);
+#define INSTRUMENT_STOP(...) timemory_end_record(inst_id);

--- a/examples/timemory/timemory_cxx_templates.hpp
+++ b/examples/timemory/timemory_cxx_templates.hpp
@@ -1,0 +1,36 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <iostream>
+#include <string>
+
+#include <timemory/timemory.hpp>
+
+using namespace tim::component;
+// using auto_timer_t = tim::auto_tuple<wall_clock, cpu_clock, peak_rss>;
+// using auto_timer_t = tim::auto_timer;
+using auto_timer_t = tim::auto_tuple<wall_clock>;
+
+#define INSTRUMENT_CONFIGURE()
+#define INSTRUMENT_CREATE(...)
+#define INSTRUMENT_START(name) TIMEMORY_BASIC_MARKER(auto_timer_t, "");
+#define INSTRUMENT_STOP(...)

--- a/examples/timemory/timemory_cxx_templates_pointer.hpp
+++ b/examples/timemory/timemory_cxx_templates_pointer.hpp
@@ -1,0 +1,36 @@
+// MIT License
+//
+// Copyright (c) 2019 NERSC
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <iostream>
+#include <string>
+
+#include <timemory/timemory.hpp>
+
+using namespace tim::component;
+// using auto_timer_t = tim::auto_tuple<wall_clock, cpu_clock, peak_rss>;
+// using auto_timer_t = tim::auto_timer;
+using auto_timer_t = tim::auto_tuple<wall_clock>;
+
+#define INSTRUMENT_CONFIGURE()
+#define INSTRUMENT_CREATE(...)
+#define INSTRUMENT_START(name) TIMEMORY_BASIC_POINTER(auto_timer_t, "");
+#define INSTRUMENT_STOP(...)

--- a/include/fallback_inst.h
+++ b/include/fallback_inst.h
@@ -22,19 +22,22 @@
 
 #pragma once
 
-//
-// will be invoked with something like:
-//      INSTRUMENT_<MODE>(...)
-//  and one can use __FILE__, __func__, and __LINE__ as needed
-//
+// configure tool before any tests are run
+#if !defined(INSTRUMENT_CONFIGURE)
+#    define INSTRUMENT_CONFIGURE()
+#endif
+
+// create something if needed
 #if !defined(INSTRUMENT_CREATE)
 #    define INSTRUMENT_CREATE(...)
 #endif
 
+// start tool as needed
 #if !defined(INSTRUMENT_START)
 #    define INSTRUMENT_START(...)
 #endif
 
+// stop tool as needed
 #if !defined(INSTRUMENT_STOP)
 #    define INSTRUMENT_STOP(...)
 #endif

--- a/include/instrumentation.h
+++ b/include/instrumentation.h
@@ -53,7 +53,6 @@ extern "C"
         int64_t* inst_count;
         double*  timing;
         double*  inst_per_sec;
-        double*  overhead;
     } c_runtime_data;
 
     //--------------------------------------------------------------------------------------//
@@ -68,12 +67,10 @@ extern "C"
         data->inst_count   = (int64_t*) malloc(nentries * sizeof(int64_t));
         data->timing       = (double*) malloc(nentries * sizeof(double));
         data->inst_per_sec = (double*) malloc(nentries * sizeof(double));
-        data->overhead     = (double*) malloc(nentries * sizeof(double));
 
         memset(data->inst_count, 0, nentries * sizeof(int64_t));
         memset(data->timing, 0, nentries * sizeof(double));
         memset(data->inst_per_sec, 0, nentries * sizeof(double));
-        memset(data->overhead, 0, nentries * sizeof(double));
     }
 
     //--------------------------------------------------------------------------------------//
@@ -83,7 +80,6 @@ extern "C"
         free(data.inst_count);
         free(data.timing);
         free(data.inst_per_sec);
-        free(data.overhead);
     }
 
     //--------------------------------------------------------------------------------------//

--- a/include/instrumentation.h
+++ b/include/instrumentation.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
 
 #if !defined(__cplusplus)
@@ -58,6 +59,32 @@ extern "C"
     //--------------------------------------------------------------------------------------//
     /// execute a test
     c_runtime_data c_execute_matmul(int64_t s, int64_t max, int64_t nitr);
+
+    //--------------------------------------------------------------------------------------//
+
+    inline void init_runtime_data(int64_t nentries, c_runtime_data* data)
+    {
+        data->entries      = nentries;
+        data->inst_count   = (int64_t*) malloc(nentries * sizeof(int64_t));
+        data->timing       = (double*) malloc(nentries * sizeof(double));
+        data->inst_per_sec = (double*) malloc(nentries * sizeof(double));
+        data->overhead     = (double*) malloc(nentries * sizeof(double));
+
+        memset(data->inst_count, 0, nentries * sizeof(int64_t));
+        memset(data->timing, 0, nentries * sizeof(double));
+        memset(data->inst_per_sec, 0, nentries * sizeof(double));
+        memset(data->overhead, 0, nentries * sizeof(double));
+    }
+
+    //--------------------------------------------------------------------------------------//
+
+    inline void free_runtime_data(c_runtime_data data)
+    {
+        free(data.inst_count);
+        free(data.timing);
+        free(data.inst_per_sec);
+        free(data.overhead);
+    }
 
     //--------------------------------------------------------------------------------------//
 

--- a/include/instrumentation.hpp
+++ b/include/instrumentation.hpp
@@ -53,13 +53,12 @@ struct cxx_runtime_data
     using dvec_t   = std::vector<double>;
     using ivec_t   = std::vector<int64_t>;
     using entry_t  = std::tuple<int64_t, int64_t, double>;
-    using result_t = std::tuple<int64_t, int64_t, double, double, double>;
+    using result_t = std::tuple<int64_t, int64_t, double, double>;
 
     int64_t entries = 0;
     ivec_t  inst_count;
     dvec_t  timing;
     dvec_t  inst_per_sec;
-    dvec_t  overhead;
 
     cxx_runtime_data()                        = default;
     ~cxx_runtime_data()                       = default;
@@ -73,7 +72,6 @@ struct cxx_runtime_data
     , inst_count(ivec_t(entries, 0))
     , timing(dvec_t(entries, 0.0))
     , inst_per_sec(dvec_t(entries, 0.0))
-    , overhead(dvec_t(entries, 0.0))
     {
     }
 
@@ -85,7 +83,6 @@ struct cxx_runtime_data
             inst_count[idx] /= std::get<1>(_div);
             timing[idx] /= std::get<1>(_div);
             inst_per_sec[idx] /= std::get<1>(_div);
-            overhead[idx] /= std::get<1>(_div);
         }
         return *this;
     }
@@ -97,15 +94,6 @@ struct cxx_runtime_data
         timing[idx] += std::get<2>(_entry);
         inst_per_sec[idx] +=
             static_cast<double>(std::get<1>(_entry)) / std::get<2>(_entry);
-        if(idx == 0)
-            overhead[idx] = 0.0;
-        else
-        {
-            auto _inst_count = std::get<1>(_entry);
-            if(_inst_count != 0)
-                overhead[idx] += (std::get<2>(_entry) - timing[0]) /
-                                 (static_cast<double>(_inst_count));
-        }
         return *this;
     }
 
@@ -115,9 +103,6 @@ struct cxx_runtime_data
         inst_count[idx]   = std::get<1>(_result);
         timing[idx]       = std::get<2>(_result);
         inst_per_sec[idx] = std::get<3>(_result);
-        overhead[idx]     = std::get<4>(_result);
-        if(inst_count[idx] < 0)
-            inst_count[idx] = 0;
         return *this;
     }
 };

--- a/include/instrumentation.hpp
+++ b/include/instrumentation.hpp
@@ -102,7 +102,7 @@ struct cxx_runtime_data
         else
         {
             auto _inst_count = std::get<1>(_entry);
-            if(std::get<2>(_entry) > timing[0] && _inst_count != 0)
+            if(_inst_count != 0)
                 overhead[idx] += (std::get<2>(_entry) - timing[0]) /
                                  (static_cast<double>(_inst_count));
         }

--- a/source/fibonacci.cpp
+++ b/source/fibonacci.cpp
@@ -154,7 +154,6 @@ launch(const int64_t& nitr, const int64_t& nfib, const int64_t& cutoff,
 cxx_runtime_data
 cxx_execute_fibonacci(int64_t nfib, int64_t cutoff, int64_t nitr)
 {
-    INSTRUMENT_CONFIGURE();
     cxx_runtime_data data(nitr + 1);
 
     std::cout << "\nRunning " << nitr << " iterations of fib(n = " << nfib
@@ -165,17 +164,11 @@ cxx_execute_fibonacci(int64_t nfib, int64_t cutoff, int64_t nitr)
     std::cout << "[warmup] fibonacci(" << nfib << ") = " << std::get<0>(warmup)
               << std::endl;
 
-#if !defined(USE_INST)
-    using inst_mode = mode::none;
-#else
-    using inst_mode = mode::inst;
-#endif
-
     //----------------------------------------------------------------------------------//
     //      run baseline and instruction mode
     //----------------------------------------------------------------------------------//
     auto ans_none = launch<mode::none>(nitr, nfib, nfib, data, 0);
-    auto ans_inst = launch<inst_mode>(nitr, nfib, cutoff, data, 1);
+    auto ans_inst = launch<mode::inst>(nitr, nfib, cutoff, data, 1);
 
     // we need to use these values so they don't get optimized away
     if(ans_none != ans_inst)

--- a/source/fibonacci.cpp
+++ b/source/fibonacci.cpp
@@ -31,3 +31,160 @@
 #include "fallback_inst.h"
 // provides structures for returning data to python
 #include "instrumentation.hpp"
+
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <tuple>
+#include <type_traits>
+
+static int64_t nmeasure = 0;
+using result_type       = std::tuple<int64_t, double>;
+
+template <bool _Ret, typename _Tp = int>
+using enable_if = typename std::enable_if<_Ret, _Tp>::type;
+
+namespace mode
+{
+// clang-format off
+struct none  {};
+struct inst  {};
+struct count {};
+// clang-format on
+}  // namespace mode
+
+//======================================================================================//
+
+int64_t
+fib(int64_t n)
+{
+    return (n < 2) ? n : (fib(n - 1) + fib(n - 2));
+}
+
+//======================================================================================//
+
+template <typename _Tp, enable_if<std::is_same<_Tp, mode::none>::value> = 0>
+int64_t
+fib(int64_t n, int64_t)
+{
+    return fib(n);
+}
+
+//======================================================================================//
+
+template <typename _Tp, enable_if<std::is_same<_Tp, mode::count>::value> = 0>
+int64_t
+fib(int64_t n, int64_t cutoff)
+{
+    if(n > cutoff)
+    {
+        nmeasure += 1;
+        return (n < 2) ? n : (fib<_Tp>(n - 1, cutoff) + fib<_Tp>(n - 2, cutoff));
+    }
+    return fib(n);
+}
+
+//======================================================================================//
+
+template <typename _Tp, enable_if<std::is_same<_Tp, mode::inst>::value> = 0>
+int64_t
+fib(int64_t n, int64_t cutoff)
+{
+    if(n > cutoff)
+    {
+        INSTRUMENT_CREATE(n);
+        INSTRUMENT_START(n);
+        int64_t ret = (n < 2) ? n : (fib<_Tp>(n - 1, cutoff) + fib<_Tp>(n - 2, cutoff));
+        INSTRUMENT_STOP(n);
+        return ret;
+    }
+    return fib(n);
+}
+
+//======================================================================================//
+
+template <typename _Tp>
+result_type
+run(int64_t n, int64_t cutoff)
+{
+    auto    t_beg  = wtime();
+    int64_t result = fib<_Tp>(n, cutoff);
+    auto    t_end  = wtime();
+    return result_type(result, t_end - t_beg);
+}
+
+//======================================================================================//
+
+template <typename _Tp>
+int64_t
+launch(const int64_t& nitr, const int64_t& nfib, const int64_t& cutoff,
+       cxx_runtime_data& data, int64_t idx_mult)
+{
+    using entry_t = std::tuple<int64_t, int64_t, double>;
+
+    // count the number of measurements and warm-up
+    nmeasure           = 0;
+    auto    ans_count  = fib<mode::count>(nfib, cutoff) * nitr;
+    int64_t inst_count = (nmeasure * nitr);
+    int64_t ans_run    = 0;
+    for(int i = 0; i < nitr; ++i)
+    {
+        auto&& ret = run<_Tp>(nfib, cutoff);
+        ans_run += std::get<0>(ret);
+        auto idx = (i + 1) * idx_mult;
+        data += entry_t(idx, inst_count, std::get<1>(ret));
+    }
+
+    if(std::is_same<_Tp, mode::none>::value && idx_mult == 0)
+        data /= std::tuple<int64_t, int64_t>(0, nitr);
+
+    // we need to use these values so they don't get optimized away
+    if(ans_count != ans_run)
+    {
+        std::stringstream ss;
+        ss << "Answer w/ counting != answer during run : " << ans_count << " vs. "
+           << ans_run;
+        throw std::runtime_error(ss.str());
+    }
+    return ans_run;
+}
+
+//======================================================================================//
+
+cxx_runtime_data
+cxx_execute_fibonacci(int64_t nfib, int64_t cutoff, int64_t nitr)
+{
+    INSTRUMENT_CONFIGURE();
+    cxx_runtime_data data(nitr + 1);
+
+    std::cout << "\nRunning " << nitr << " iterations of fib(n = " << nfib
+              << ", cutoff = " << cutoff << ")...\n"
+              << std::endl;
+
+    auto warmup = run<mode::none>(nfib, nfib);
+    std::cout << "[warmup] fibonacci(" << nfib << ") = " << std::get<0>(warmup)
+              << std::endl;
+
+#if !defined(USE_INST)
+    using inst_mode = mode::none;
+#else
+    using inst_mode = mode::inst;
+#endif
+
+    //----------------------------------------------------------------------------------//
+    //      run baseline and instruction mode
+    //----------------------------------------------------------------------------------//
+    auto ans_none = launch<mode::none>(nitr, nfib, nfib, data, 0);
+    auto ans_inst = launch<inst_mode>(nitr, nfib, cutoff, data, 1);
+
+    // we need to use these values so they don't get optimized away
+    if(ans_none != ans_inst)
+    {
+        std::stringstream ss;
+        ss << "Answer w/o instrumentation != answer w/ instrumentation : " << ans_none
+           << " vs. " << ans_inst;
+        throw std::runtime_error(ss.str());
+    }
+
+    return data;
+}

--- a/source/fibonacci.cpp
+++ b/source/fibonacci.cpp
@@ -154,8 +154,7 @@ cxx_execute_fibonacci(int64_t nfib, int64_t cutoff, int64_t nitr)
     cxx_runtime_data data(nitr);
 
     std::cout << "\nRunning " << nitr << " iterations of fib(n = " << nfib
-              << ", cutoff = " << cutoff << ")..."
-              << std::endl;
+              << ", cutoff = " << cutoff << ")..." << std::endl;
 
     //----------------------------------------------------------------------------------//
     //      run baseline (warm-up) and instruction mode

--- a/source/matmul.c
+++ b/source/matmul.c
@@ -86,7 +86,7 @@ c_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
 {
     INSTRUMENT_CONFIGURE();
 
-    printf("Running %" PRId64 " a MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
+    printf("Running %" PRId64 " MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
     double* a = (double*) malloc(s * s * sizeof(double));
     double* b = (double*) malloc(s * s * sizeof(double));
     double* c = (double*) malloc(s * s * sizeof(double));
@@ -113,10 +113,6 @@ c_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
             inst_count += mm(s, a, b, c);
         double t_end  = wtime();
         double t_diff = t_end - t_beg;
-        if(t_diff < 0.0)
-            t_diff = 0.0;
-        if(inst_count < 0)
-            inst_count = 0;
 
         data.inst_count[0] += inst_count;
         data.timing[0] += t_diff;
@@ -143,15 +139,13 @@ c_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
         }
         double t_end  = wtime();
         double t_diff = t_end - t_beg;
-        if(t_diff < 0.0)
-            t_diff = 0.0;
 
         int idx                = i + 1;
         data.inst_count[idx]   = inst_count;
         data.timing[idx]       = t_diff;
         data.inst_per_sec[idx] = ((double) inst_count) / t_diff;
 
-        if(t_diff > data.timing[0] && inst_count != 0)
+        if(inst_count != 0)
             data.overhead[idx] = ((t_diff - data.timing[0]) / ((double) inst_count));
         else
             data.overhead[idx] = 0.0;

--- a/source/matmul.c
+++ b/source/matmul.c
@@ -103,7 +103,7 @@ mm_reset(int64_t s, double* a, double* b, double* c)
 c_runtime_data
 c_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
 {
-    printf("Running %" PRId64 " MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
+    printf("\nRunning %" PRId64 " MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
     double* a = (double*) malloc(s * s * sizeof(double));
     double* b = (double*) malloc(s * s * sizeof(double));
     double* c = (double*) malloc(s * s * sizeof(double));

--- a/source/matmul.cpp
+++ b/source/matmul.cpp
@@ -105,7 +105,7 @@ cxx_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
     using ivec_t  = std::vector<int64_t>;
     using entry_t = std::tuple<int64_t, int64_t, double>;
 
-    printf("Running %" PRId64 " MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
+    printf("\nRunning %" PRId64 " MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
     auto _a = dvec_t(s * s, 0.0);
     auto _b = dvec_t(s * s, 0.0);
     auto _c = dvec_t(s * s, 0.0);

--- a/source/matmul.cpp
+++ b/source/matmul.cpp
@@ -90,7 +90,7 @@ cxx_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
     using ivec_t  = std::vector<int64_t>;
     using entry_t = std::tuple<int64_t, int64_t, double>;
 
-    printf("Running %" PRId64 " a MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
+    printf("Running %" PRId64 " MM on %" PRId64 " x %" PRId64 "\n", imax, s, s);
     auto _a = dvec_t(s * s, 0.0);
     auto _b = dvec_t(s * s, 0.0);
     auto _c = dvec_t(s * s, 0.0);
@@ -114,22 +114,21 @@ cxx_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
     // base-line
     for(int64_t i = 0; i < nitr; ++i)
     {
-        double  t1         = wtime();
+        double  t_beg      = wtime();
         int64_t inst_count = 0;
         for(int64_t iter = 0; iter < imax; iter++)
             inst_count += mm(s, a, b, c);
-        double tdiff = wtime() - t1;
-        if(tdiff < 0.0)
-            tdiff = 0.0;
+        double t_end  = wtime();
+        double t_diff = t_end - t_beg;
 
-        data += entry_t(0, inst_count, tdiff);
+        data += entry_t(0, inst_count, t_diff);
     }
     data /= std::tuple<int64_t, int64_t>(0, nitr);
 
     // with instrumentation
     for(int64_t i = 0; i < nitr; ++i)
     {
-        double  t1         = wtime();
+        double  t_beg      = wtime();
         int64_t inst_count = 0;
         for(int64_t iter = 0; iter < imax; iter++)
 #if !defined(USE_INST)
@@ -137,11 +136,10 @@ cxx_execute_matmul(int64_t s, int64_t imax, int64_t nitr)
 #else
             inst_count += mm_inst(s, a, b, c);
 #endif
-        double tdiff = wtime() - t1;
-        if(tdiff < 0.0)
-            tdiff = 0.0;
+        double t_end  = wtime();
+        double t_diff = t_end - t_beg;
 
-        data += entry_t(i + 1, inst_count, tdiff);
+        data += entry_t(i + 1, inst_count, t_diff);
     }
 
     return data;

--- a/source/python/libinstrument_benchmark.cpp
+++ b/source/python/libinstrument_benchmark.cpp
@@ -57,6 +57,8 @@
 
 #include <string>
 
+#include "@SUBMODULE_HEADER_FILE@"
+
 #include "instrumentation.h"
 #include "instrumentation.hpp"
 

--- a/source/python/libinstrument_benchmark.cpp
+++ b/source/python/libinstrument_benchmark.cpp
@@ -65,6 +65,7 @@
 
 namespace py   = pybind11;
 using string_t = std::string;
+using dvec_t   = std::vector<double>;
 
 template <typename... _Args>
 void
@@ -86,10 +87,9 @@ PYBIND11_MODULE(INST_MODULE_NAME, inst)
         c_runtime_data ret = c_execute_matmul(s, max, nitr);
         // convert to C++ type
         cxx_runtime_data _data(ret.entries);
-        using result_t = std::tuple<int64_t, int64_t, double, double, double>;
+        using result_t = std::tuple<int64_t, int64_t, double, double>;
         for(int64_t j = 0; j < ret.entries; ++j)
-            _data += result_t(j, ret.inst_count[j], ret.timing[j], ret.inst_per_sec[j],
-                              ret.overhead[j]);
+            _data += result_t(j, ret.inst_count[j], ret.timing[j], ret.inst_per_sec[j]);
         free_runtime_data(ret);
         return _data;
     };
@@ -192,12 +192,33 @@ PYBIND11_MODULE(INST_MODULE_NAME, inst)
     //----------------------------------------------------------------------------------//
 
 #if defined(BUILD_RUNTIME_DATA_BINDINGS)
+    auto overhead = [](cxx_runtime_data* current, cxx_runtime_data* baseline) -> dvec_t {
+        if(!baseline)
+            baseline = current;
+        dvec_t overhead(current->entries, 0.0);
+        double bsize = baseline->entries;
+        double tmean = 0.0;
+        for(const auto& itr : baseline->timing)
+            tmean += itr;
+        tmean /= bsize;
+        const auto& timing = current->timing;
+        const auto& instct = current->inst_count;
+        for(uint64_t i = 0; i < overhead.size(); ++i)
+            overhead[i] = (timing[i] - tmean) / static_cast<double>(instct[i]);
+        return overhead;
+    };
+
     py::class_<cxx_runtime_data> runtime_data(inst, "runtime_data");
     runtime_data.def(py::init<>(), "construct runtime_data");
-    runtime_data.def("entries", [](cxx_runtime_data* d) { return d->entries; });
-    runtime_data.def("inst_count", [](cxx_runtime_data* d) { return d->inst_count; });
-    runtime_data.def("timing", [](cxx_runtime_data* d) { return d->timing; });
-    runtime_data.def("inst_per_sec", [](cxx_runtime_data* d) { return d->inst_per_sec; });
-    runtime_data.def("overhead", [](cxx_runtime_data* d) { return d->overhead; });
+    runtime_data.def("entries", [](cxx_runtime_data* d) { return d->entries; },
+                     "Get the number of entries");
+    runtime_data.def("inst_count", [](cxx_runtime_data* d) { return d->inst_count; },
+                     "Get number of measurements");
+    runtime_data.def("timing", [](cxx_runtime_data* d) { return d->timing; },
+                     "Get the timing entries");
+    runtime_data.def("inst_per_sec", [](cxx_runtime_data* d) { return d->inst_per_sec; },
+                     "Get instructions-per-second");
+    runtime_data.def("overhead", overhead, "Compute the overhead w.r.t. a baseline",
+                     py::arg("baseline") = nullptr);
 #endif
 }

--- a/source/python/libinstrument_benchmark.cpp
+++ b/source/python/libinstrument_benchmark.cpp
@@ -60,6 +60,9 @@
 #include "instrumentation.h"
 #include "instrumentation.hpp"
 
+// provides instrumentation definitions if not
+#include "fallback_inst.h"
+
 namespace py   = pybind11;
 using string_t = std::string;
 
@@ -116,6 +119,8 @@ PYBIND11_MODULE(INST_MODULE_NAME, inst)
     //----------------------------------------------------------------------------------//
 
     auto execute_matmul = [&](int64_t s, int64_t max, int64_t nitr, std::string lang) {
+        INSTRUMENT_CONFIGURE();
+
         for(auto& itr : lang)
             itr = tolower(itr);
 
@@ -147,6 +152,8 @@ PYBIND11_MODULE(INST_MODULE_NAME, inst)
 
     auto execute_fibonacci = [&](int64_t nfib, int64_t cutoff, int64_t nitr,
                                  std::string lang) {
+        INSTRUMENT_CONFIGURE();
+
         for(auto& itr : lang)
             itr = tolower(itr);
 


### PR DESCRIPTION
## In this PR

- Most important update was the sharing of the baseline between multiple configurations and deferring the overhead until a baseline is provided
    - Thus one should run the baseline submodule first and pass that result to the `cxx_runtime_data.overhead(...)` method in Python
- various fixes to the testing build system
- `examples/execute.py` provides plotting
- Added `examples/timemory` and a `examples/timemory/configure.sh` that will copy the files into the appropriate locations
    - @daboehme this can be used for CI. We could install timemory (which would also install caliper) or something else, execute a script like this, and then run.

## TO-DO

- Still need to start designing the common API
- The C version of the fibonacci test still needs to be written
- Multithreaded version
    - We can start the threads from Python and run tests in parallel -> the idea here would be benchmarking the performance of the tool in a parallel context
- MPI version
- MPI + threads version
- More examples
    - TAU, Caliper loop markers, etc.